### PR TITLE
Make Channel#basic_nack send a Basic::Nack frame

### DIFF
--- a/src/amqp-client/channel.cr
+++ b/src/amqp-client/channel.cr
@@ -266,7 +266,7 @@ class AMQP::Client
     end
 
     def basic_nack(delivery_tag : UInt64, requeue = false, multiple = false) : Nil
-      write Frame::Basic::Reject.new(@id, delivery_tag, multiple, requeue)
+      write Frame::Basic::Nack.new(@id, delivery_tag, multiple, requeue)
     end
 
     def basic_qos(count, global = false) : Nil


### PR DESCRIPTION
It was trying to send a Basic::Reject which takes a different number of arguments and generating this error:

```
In src/message_processor.cr:25:17

 25 | channel.basic_nack message.delivery_tag, requeue: true
              ^---------
Error: instantiating 'AMQP::Client::Channel#basic_nack(UInt64)'


In lib/amqp-client/src/amqp-client/channel.cr:268:5

 268 | def basic_nack(delivery_tag : UInt64, requeue = false, multiple = false) : Nil
       ^---------
Error: instantiating 'basic_nack(UInt64, Bool, Bool)'


In lib/amqp-client/src/amqp-client/channel.cr:269:34

 269 | write Frame::Basic::Reject.new(@id, delivery_tag, multiple, requeue)
                                  ^--
Error: wrong number of arguments for 'AMQ::Protocol::Frame::Basic::Reject.new' (given 4, expected 3)

Overloads are:
 - AMQ::Protocol::Frame::Basic::Reject.new(channel, delivery_tag : UInt64, requeue : Bool)
```