### PR TITLE
channel#basic_cancel

### DIFF
--- a/src/amqp-client/channel.cr
+++ b/src/amqp-client/channel.cr
@@ -19,14 +19,13 @@ class AMQP::Client
     @reply_frames = ::Channel(Frame).new
     @next_msg_ready = ::Channel(Nil).new
 
-    @deliveries = ::Channel(Tuple(Frame::Basic::Deliver, Properties, IO::Memory) | Tuple(Frame::Basic::CancelOk, Nil, Nil)).new(8192)
+    alias DeliveryOrCancel = Tuple(Frame::Basic::Deliver, Properties, IO::Memory) | Tuple(Frame::Basic::CancelOk, Nil, Nil)
+
     @returns = ::Channel(Tuple(Frame::Basic::Return, Properties, IO::Memory)).new(1024)
     @confirms = ::Channel(Frame::Basic::Ack | Frame::Basic::Nack).new(8192)
-    @consumer_unacked_count = Hash(String, UInt32).new(0)
 
     def initialize(@connection : Connection, @id : UInt16)
       spawn read_loop, name: "Channel #{@id} read_loop", same_thread: true
-      spawn delivery_loop, name: "Channel #{@id} delivery_loop", same_thread: true
       spawn return_loop, name: "Channel #{@id} return_loop", same_thread: true
       spawn confirm_loop, name: "Channel #{@id} confirm_loop", same_thread: true
     end
@@ -75,9 +74,9 @@ class AMQP::Client
     def cleanup
       @server_frames.close
       @reply_frames.close
-      @deliveries.close
       @returns.close
       @confirms.close
+      @consumers.each_value(&.close)
     end
 
     @next_body_io = IO::Memory.new(0)
@@ -141,52 +140,53 @@ class AMQP::Client
         LOG.error(exception: ex) { "Uncaught exception in on_cancel" }
       end
 
-      if cb = @consumer_blocks.delete f.consumer_tag
-        cb.close
-      end
       cancel_ok = Frame::Basic::CancelOk.new(@id, f.consumer_tag)
-      @deliveries.send({ cancel_ok, nil, nil })
+      process_cancel_ok(cancel_ok)
       write cancel_ok unless f.no_wait
     end
 
     private def process_cancel_ok(f : Frame::Basic::CancelOk)
-      @deliveries.send({ f, nil, nil })
+      if deliveries = @consumers[f.consumer_tag]?
+        deliveries.send({ f, nil, nil })
+      else
+        LOG.warn { "Consumer tag '#{f.consumer_tag}' already cancelled" }
+      end
     end
 
     private def process_deliver(f : Frame::Basic::Deliver)
       @next_msg_ready.receive
-      @consumer_unacked_count[f.consumer_tag] += 1
-      @deliveries.send({f, @next_msg_props, @next_body_io})
+      if deliveries = @consumers[f.consumer_tag]?
+        deliveries.send({ f, @next_msg_props, @next_body_io})
+      else
+        LOG.warn { "Consumer tag '#{f.consumer_tag}' not found" }
+      end
     end
 
-    private def delivery_loop
-      LOG.context.set channel_id: @id.to_i, fiber: "deliver_loop"
+    private def consume(consumer_tag, deliveries, blk)
+      LOG.context.set channel_id: @id.to_i, consumer: consumer_tag, fiber: "consumer##{consumer_tag}"
       loop do
-        f, props, body_io = @deliveries.receive
+        f, props, body_io = deliveries.receive
         case f
         when Frame::Basic::CancelOk
           @consumers.delete(f.consumer_tag)
           if cb = @consumer_blocks.delete f.consumer_tag
             cb.close
           end
+          deliveries.close
+          break
         when Frame::Basic::Deliver
           props = props.not_nil!
           body_io = body_io.not_nil!
           msg = DeliverMessage.new(self, f.exchange, f.routing_key,
             f.delivery_tag, props, body_io, f.redelivered)
-          if consumer = @consumers.fetch(f.consumer_tag, nil)
-            begin
-              consumer.call(msg)
-              @consumer_unacked_count[f.consumer_tag] -= 1
-            rescue ex
-              if cb = @consumer_blocks.delete f.consumer_tag
-                cb.send ex
-              else
-                LOG.error(exception: ex) { "Uncaught exception in consumer" }
-              end
+          begin
+            blk.call(msg)
+          rescue ex
+            if cb = @consumer_blocks.delete f.consumer_tag
+              cb.send ex
+            else
+              LOG.error(exception: ex) { "Uncaught exception in consumer" }
             end
-          else
-            LOG.warn { "Consumer tag '#{f.consumer_tag}' not found" }
           end
         end
       rescue ::Channel::ClosedError
@@ -347,7 +347,7 @@ class AMQP::Client
       @consumers.has_key? consumer_tag
     end
 
-    @consumers = Sync(Hash(String, Proc(DeliverMessage, Nil))).new
+    @consumers = Sync(Hash(String, ::Channel(DeliveryOrCancel))).new
     @consumer_blocks = Sync(Hash(String, ::Channel(Exception))).new
 
     def basic_consume(queue, tag = "", no_ack = true, exclusive = false,
@@ -355,7 +355,9 @@ class AMQP::Client
                       args = Arguments.new, &blk : DeliverMessage -> Nil)
       write Frame::Basic::Consume.new(@id, 0_u16, queue, tag, false, no_ack, exclusive, false, args)
       ok = expect Frame::Basic::ConsumeOk
-      @consumers[ok.consumer_tag] = blk
+      delivery_channel = ::Channel(DeliveryOrCancel).new(8192)
+      @consumers[ok.consumer_tag] = delivery_channel
+      spawn consume(ok.consumer_tag, delivery_channel, blk), name: "AMQPconsumer##{ok.consumer_tag}", same_thread: true
       if block
         cb = @consumer_blocks[ok.consumer_tag] = ::Channel(Exception).new
         if ex = cb.receive?

--- a/src/amqp-client/channel.cr
+++ b/src/amqp-client/channel.cr
@@ -19,7 +19,7 @@ class AMQP::Client
     @reply_frames = ::Channel(Frame).new
     @next_msg_ready = ::Channel(Nil).new
 
-    @deliveries = ::Channel(Tuple(Frame::Basic::Deliver, Properties, IO::Memory)).new(8192)
+    @deliveries = ::Channel(Tuple(Frame::Basic::Deliver, Properties, IO::Memory) | Tuple(Frame::Basic::CancelOk, Nil, Nil)).new(8192)
     @returns = ::Channel(Tuple(Frame::Basic::Return, Properties, IO::Memory)).new(1024)
     @confirms = ::Channel(Frame::Basic::Ack | Frame::Basic::Nack).new(8192)
     @consumer_unacked_count = Hash(String, UInt32).new(0)
@@ -88,7 +88,8 @@ class AMQP::Client
       case frame
       when Frame::Basic::Deliver,
            Frame::Basic::Return,
-           Frame::Basic::Cancel
+           Frame::Basic::Cancel,
+           Frame::Basic::CancelOk
         @server_frames.send frame
       when Frame::Basic::Ack, Frame::Basic::Nack
         @confirms.send frame
@@ -117,10 +118,11 @@ class AMQP::Client
       loop do
         frame = @server_frames.receive? || break
         case frame
-        when Frame::Basic::Deliver then process_deliver(frame)
-        when Frame::Basic::Return  then process_return(frame)
-        when Frame::Basic::Cancel  then process_cancel(frame)
-        else                            raise UnexpectedFrame.new(frame)
+        when Frame::Basic::Deliver  then process_deliver(frame)
+        when Frame::Basic::Return   then process_return(frame)
+        when Frame::Basic::Cancel   then process_cancel(frame)
+        when Frame::Basic::CancelOk then process_cancel_ok(frame)
+        else                             raise UnexpectedFrame.new(frame)
         end
       end
     end
@@ -142,7 +144,13 @@ class AMQP::Client
       if cb = @consumer_blocks.delete f.consumer_tag
         cb.close
       end
-      write Frame::Basic::CancelOk.new(@id, f.consumer_tag) unless f.no_wait
+      cancel_ok = Frame::Basic::CancelOk.new(@id, f.consumer_tag)
+      @deliveries.send({ cancel_ok, nil, nil })
+      write cancel_ok unless f.no_wait
+    end
+
+    private def process_cancel_ok(f : Frame::Basic::CancelOk)
+      @deliveries.send({ f, nil, nil })
     end
 
     private def process_deliver(f : Frame::Basic::Deliver)
@@ -155,21 +163,31 @@ class AMQP::Client
       LOG.context.set channel_id: @id.to_i, fiber: "deliver_loop"
       loop do
         f, props, body_io = @deliveries.receive
-        msg = DeliverMessage.new(self, f.exchange, f.routing_key,
-          f.delivery_tag, props, body_io, f.redelivered)
-        if consumer = @consumers.fetch(f.consumer_tag, nil)
-          begin
-            consumer.call(msg)
-            @consumer_unacked_count[f.consumer_tag] -= 1
-          rescue ex
-            if cb = @consumer_blocks.delete f.consumer_tag
-              cb.send ex
-            else
-              LOG.error(exception: ex) { "Uncaught exception in consumer" }
-            end
+        case f
+        when Frame::Basic::CancelOk
+          @consumers.delete(f.consumer_tag)
+          if cb = @consumer_blocks.delete f.consumer_tag
+            cb.close
           end
-        else
-          LOG.warn { "Consumer tag '#{f.consumer_tag}' not found" }
+        when Frame::Basic::Deliver
+          props = props.not_nil!
+          body_io = body_io.not_nil!
+          msg = DeliverMessage.new(self, f.exchange, f.routing_key,
+            f.delivery_tag, props, body_io, f.redelivered)
+          if consumer = @consumers.fetch(f.consumer_tag, nil)
+            begin
+              consumer.call(msg)
+              @consumer_unacked_count[f.consumer_tag] -= 1
+            rescue ex
+              if cb = @consumer_blocks.delete f.consumer_tag
+                cb.send ex
+              else
+                LOG.error(exception: ex) { "Uncaught exception in consumer" }
+              end
+            end
+          else
+            LOG.warn { "Consumer tag '#{f.consumer_tag}' not found" }
+          end
         end
       rescue ::Channel::ClosedError
         break
@@ -348,12 +366,8 @@ class AMQP::Client
       ok.consumer_tag
     end
 
-    def basic_cancel(consumer_tag, no_wait = false) : Nil
-      write Frame::Basic::Cancel.new(@id, consumer_tag, no_wait)
-      expect Frame::Basic::CancelOk unless no_wait
-      if cb = @consumer_blocks.delete consumer_tag
-        cb.close
-      end
+    def basic_cancel(consumer_tag) : Nil
+      write Frame::Basic::Cancel.new(@id, consumer_tag, no_wait: false)
     end
 
     def basic_ack(delivery_tag : UInt64, multiple = false) : Nil

--- a/src/amqp-client/queue.cr
+++ b/src/amqp-client/queue.cr
@@ -42,8 +42,8 @@ class AMQP::Client
       @channel.basic_consume(@name, tag, no_ack, exclusive, block, args, &blk)
     end
 
-    def unsubscribe(consumer_tag, no_wait = false)
-      @channel.basic_cancel(consumer_tag, no_wait)
+    def unsubscribe(consumer_tag)
+      @channel.basic_cancel(consumer_tag)
     end
 
     def purge


### PR DESCRIPTION
Subscriber should still process the messages it's assigned to

> This method cancels a consumer. This does not affect already delivered messages, but it does mean the server will not send any more messages for that consumer. The client may receive an arbitrary number of messages in between sending the cancel method and receiving the cancel-ok reply. https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.cancel

Co-authored-by: Anders Bälter <anders@84codes.com>