### PR TITLE
Bump pages-deploy-action version

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build
         run:  crystal docs lib/amq-protocol/src/amq-protocol.cr src/amqp-client.cr
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@3.6.1
+        uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages


### PR DESCRIPTION
Required due to an Actions deprecation.  See:

* https://github.com/JamesIves/github-pages-deploy-action/issues/500
* https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/