### PR TITLE
Fix Channel#basic_get not raising ClosedException

### DIFF
--- a/spec/amqp-client_spec.cr
+++ b/spec/amqp-client_spec.cr
@@ -108,6 +108,16 @@ describe AMQP::Client do
     end
   end
 
+  context "Channel#basic_get" do
+    it "should raise ClosedException when trying to use non-existing queue" do
+      with_channel do |ch|
+        expect_raises(AMQP::Client::Channel::ClosedException, /404/) do
+          ch.basic_get("foobar", no_ack: true)
+        end
+      end
+    end
+  end
+
   it "should not break connection on Channel::ClosedException" do
     with_connection do |c|
       ch = c.channel

--- a/src/amqp-client/channel.cr
+++ b/src/amqp-client/channel.cr
@@ -305,9 +305,15 @@ class AMQP::Client
     # The message must eventually be acked or rejected if *no_ack* is false
     def basic_get(queue : String, no_ack = true) : GetMessage?
       write Frame::Basic::Get.new(@id, 0_u16, queue, no_ack)
-      @basic_get.receive?
-    ensure
-      raise ClosedException.new(@closing_frame) if @closing_frame
+      @basic_get.receive
+    rescue ex : ::Channel::ClosedError
+      if cf = @connection.closing_frame
+        raise Connection::ClosedException.new(cf)
+      elsif cf = @closing_frame
+        raise ClosedException.new(cf, cause: ex)
+      else
+        raise ex
+      end
     end
 
     # :nodoc:

--- a/src/amqp-client/channel.cr
+++ b/src/amqp-client/channel.cr
@@ -306,6 +306,8 @@ class AMQP::Client
     def basic_get(queue : String, no_ack = true) : GetMessage?
       write Frame::Basic::Get.new(@id, 0_u16, queue, no_ack)
       @basic_get.receive?
+    ensure
+      raise ClosedException.new(@closing_frame) if @closing_frame
     end
 
     # :nodoc:


### PR DESCRIPTION
Introduced in d2d9fd50d57720753e996bcc11e131100c0bc0d6

v1.0.4 contains this bug, has `.receive` instead of `.receive?` which
raises a Channel::ClosedError (Crystal Channel) which was fixed in
80ba77385e80d8582d0fefff65ae75e718e21bd9.