### PR TITLE
let a client accept external client_args

### DIFF
--- a/src/amqp-client.cr
+++ b/src/amqp-client.cr
@@ -103,7 +103,7 @@ class AMQP::Client
     property nodelay, keepalive_idle, keepalive_interval, keepalive_count, send_buffer_size, recv_buffer_size
   end
 
-  record ConnectionInformation, product : String? = nil, product_version : String? = nil, platform : String? = nil, platform_version : String? = nil do
+  record ConnectionInformation, product = "amqp-client.cr", product_version = AMQP::Client::VERSION, platform = "Crystal", platform_version = Crystal::VERSION do
     property product, product_version, platform, platform_version
   end
 

--- a/src/amqp-client.cr
+++ b/src/amqp-client.cr
@@ -103,13 +103,14 @@ class AMQP::Client
     property nodelay, keepalive_idle, keepalive_interval, keepalive_count, send_buffer_size, recv_buffer_size
   end
 
-  record ConnectionInformation, product = "amqp-client.cr", product_version = AMQP::Client::VERSION, platform = "Crystal", platform_version = Crystal::VERSION do
+  record ConnectionInformation, product : String? = "amqp-client.cr", product_version : String? = nil, platform : String? = "Crystal", platform_version : String? = nil do
     property product, product_version, platform, platform_version
   end
 
   def initialize(@host = AMQP_HOST, @port = AMQP_PORT, @vhost = AMQP_VHOST, @user = AMQP_USER, @password = AMQP_PASS,
                  tls : TLSContext = AMQP_TLS, @websocket = AMQP_WS, @channel_max = 1024_u16, @frame_max = 131_072_u32, @heartbeat = 0_u16,
-                 verify_mode = OpenSSL::SSL::VerifyMode::PEER, @name : String? = File.basename(PROGRAM_NAME), @connection_information = ConnectionInformation.new,
+                 verify_mode = OpenSSL::SSL::VerifyMode::PEER, @name : String? = File.basename(PROGRAM_NAME),
+                 @connection_information = ConnectionInformation.new("amqp-client.cr", AMQP::Client::VERSION, "Crystal", Crystal::VERSION),
                  @tcp = TCPConfig.new, @buffer_size = 16_384)
     if tls.is_a? OpenSSL::SSL::Context::Client
       @tls = tls

--- a/src/amqp-client.cr
+++ b/src/amqp-client.cr
@@ -103,14 +103,14 @@ class AMQP::Client
     property nodelay, keepalive_idle, keepalive_interval, keepalive_count, send_buffer_size, recv_buffer_size
   end
 
-  record ConnectionInformation, product : String? = "amqp-client.cr", product_version : String? = nil, platform : String? = "Crystal", platform_version : String? = nil do
-    property product, product_version, platform, platform_version
+  record ConnectionInformation, name : String? = nil, product : String? = "amqp-client.cr", product_version : String? = nil, platform : String? = "Crystal", platform_version : String? = nil do
+    property name, product, product_version, platform, platform_version
   end
 
   def initialize(@host = AMQP_HOST, @port = AMQP_PORT, @vhost = AMQP_VHOST, @user = AMQP_USER, @password = AMQP_PASS,
                  tls : TLSContext = AMQP_TLS, @websocket = AMQP_WS, @channel_max = 1024_u16, @frame_max = 131_072_u32, @heartbeat = 0_u16,
                  verify_mode = OpenSSL::SSL::VerifyMode::PEER, @name : String? = File.basename(PROGRAM_NAME),
-                 @connection_information = ConnectionInformation.new("amqp-client.cr", AMQP::Client::VERSION, "Crystal", Crystal::VERSION),
+                 @connection_information = ConnectionInformation.new(File.basename(PROGRAM_NAME), "amqp-client.cr", AMQP::Client::VERSION, "Crystal", Crystal::VERSION),
                  @tcp = TCPConfig.new, @buffer_size = 16_384)
     if tls.is_a? OpenSSL::SSL::Context::Client
       @tls = tls

--- a/src/amqp-client.cr
+++ b/src/amqp-client.cr
@@ -103,14 +103,14 @@ class AMQP::Client
     property nodelay, keepalive_idle, keepalive_interval, keepalive_count, send_buffer_size, recv_buffer_size
   end
 
-  record ConnectionInformation, name : String? = nil, product : String? = "amqp-client.cr", product_version : String? = nil, platform : String? = "Crystal", platform_version : String? = nil do
-    property name, product, product_version, platform, platform_version
+  record ConnectionInformation, product : String? = "amqp-client.cr", product_version : String? = nil, platform : String? = "Crystal", platform_version : String? = nil, name : String? = nil do
+    property product, product_version, platform, platform_version, name
   end
 
   def initialize(@host = AMQP_HOST, @port = AMQP_PORT, @vhost = AMQP_VHOST, @user = AMQP_USER, @password = AMQP_PASS,
                  tls : TLSContext = AMQP_TLS, @websocket = AMQP_WS, @channel_max = 1024_u16, @frame_max = 131_072_u32, @heartbeat = 0_u16,
                  verify_mode = OpenSSL::SSL::VerifyMode::PEER, @name : String? = File.basename(PROGRAM_NAME),
-                 @connection_information = ConnectionInformation.new(File.basename(PROGRAM_NAME), "amqp-client.cr", AMQP::Client::VERSION, "Crystal", Crystal::VERSION),
+                 @connection_information = ConnectionInformation.new("amqp-client.cr", AMQP::Client::VERSION, "Crystal", Crystal::VERSION, File.basename(PROGRAM_NAME)),
                  @tcp = TCPConfig.new, @buffer_size = 16_384)
     if tls.is_a? OpenSSL::SSL::Context::Client
       @tls = tls

--- a/src/amqp-client.cr
+++ b/src/amqp-client.cr
@@ -39,7 +39,7 @@ class AMQP::Client
   def self.start(host = AMQP_HOST, port = AMQP_PORT, vhost = AMQP_VHOST,
                  user = AMQP_USER, password = AMQP_PASS, tls : TLSContext = AMQP_TLS, websocket = AMQP_WS,
                  channel_max = 1024_u16, frame_max = 131_072_u32, heartbeat = 0_u16,
-                 verify_mode = OpenSSL::SSL::VerifyMode::PEER, name = nil, connection_information : ConnectionInformation? = nil, & : AMQP::Client::Connection -> _)
+                 verify_mode = OpenSSL::SSL::VerifyMode::PEER, name = nil, connection_information = ConnectionInformation.new, & : AMQP::Client::Connection -> _)
     conn = self.new(host, port, vhost, user, password, tls, websocket, channel_max, frame_max, heartbeat, verify_mode, name, connection_information).connect
     yield conn
   ensure
@@ -92,7 +92,7 @@ class AMQP::Client
     end
     self.new(host, port, vhost, user, password, tls, websocket,
       channel_max, frame_max, heartbeat, verify_mode, name,
-      tcp, buffer_size, connection_information)
+      connection_information, tcp, buffer_size)
   end
 
   property host, port, vhost, user, websocket, tcp, buffer_size
@@ -109,8 +109,8 @@ class AMQP::Client
 
   def initialize(@host = AMQP_HOST, @port = AMQP_PORT, @vhost = AMQP_VHOST, @user = AMQP_USER, @password = AMQP_PASS,
                  tls : TLSContext = AMQP_TLS, @websocket = AMQP_WS, @channel_max = 1024_u16, @frame_max = 131_072_u32, @heartbeat = 0_u16,
-                 verify_mode = OpenSSL::SSL::VerifyMode::PEER, @name : String? = File.basename(PROGRAM_NAME),
-                 @tcp = TCPConfig.new, @buffer_size = 16_384, @connection_information : ConnectionInformation? = nil)
+                 verify_mode = OpenSSL::SSL::VerifyMode::PEER, @name : String? = File.basename(PROGRAM_NAME), @connection_information = ConnectionInformation.new,
+                 @tcp = TCPConfig.new, @buffer_size = 16_384)
     if tls.is_a? OpenSSL::SSL::Context::Client
       @tls = tls
     elsif tls == true

--- a/src/amqp-client.cr
+++ b/src/amqp-client.cr
@@ -29,8 +29,8 @@ class AMQP::Client
 
   alias TLSContext = OpenSSL::SSL::Context::Client | Bool | Nil
 
-  def self.start(url : String | URI, client_args = nil, & : AMQP::Client::Connection -> _)
-    conn = self.new(url, client_args).connect
+  def self.start(url : String | URI, connection_information : ConnectionInformation? = nil, & : AMQP::Client::Connection -> _)
+    conn = self.new(url, connection_information).connect
     yield conn
   ensure
     conn.try &.close
@@ -39,19 +39,19 @@ class AMQP::Client
   def self.start(host = AMQP_HOST, port = AMQP_PORT, vhost = AMQP_VHOST,
                  user = AMQP_USER, password = AMQP_PASS, tls : TLSContext = AMQP_TLS, websocket = AMQP_WS,
                  channel_max = 1024_u16, frame_max = 131_072_u32, heartbeat = 0_u16,
-                 verify_mode = OpenSSL::SSL::VerifyMode::PEER, name = nil, client_args = nil, & : AMQP::Client::Connection -> _)
-    conn = self.new(host, port, vhost, user, password, tls, websocket, channel_max, frame_max, heartbeat, verify_mode, name, client_args).connect
+                 verify_mode = OpenSSL::SSL::VerifyMode::PEER, name = nil, connection_information : ConnectionInformation? = nil, & : AMQP::Client::Connection -> _)
+    conn = self.new(host, port, vhost, user, password, tls, websocket, channel_max, frame_max, heartbeat, verify_mode, name, connection_information).connect
     yield conn
   ensure
     conn.try &.close
   end
 
-  def self.new(url : String, client_args = nil)
+  def self.new(url : String, connection_information : ConnectionInformation? = nil)
     uri = URI.parse(url)
-    self.new(uri)
+    self.new(uri, connection_information)
   end
 
-  def self.new(uri : URI, client_args = nil) # ameba:disable Metrics/CyclomaticComplexity
+  def self.new(uri : URI, connection_information : ConnectionInformation? = nil) # ameba:disable Metrics/CyclomaticComplexity
     tls = TLS_SCHEMES.includes? uri.scheme
     websocket = WS_SCHEMES.includes? uri.scheme
     host = uri.host.to_s.empty? ? "localhost" : uri.host.to_s
@@ -87,7 +87,7 @@ class AMQP::Client
     end
     self.new(host, port, vhost, user, password, tls, websocket,
       channel_max, frame_max, heartbeat, verify_mode, name,
-      tcp, buffer_size, client_args)
+      tcp, buffer_size, connection_information)
   end
 
   property host, port, vhost, user, websocket, tcp, buffer_size
@@ -98,10 +98,14 @@ class AMQP::Client
     property nodelay, keepalive_idle, keepalive_interval, keepalive_count, send_buffer_size, recv_buffer_size
   end
 
+  record ConnectionInformation, product : String? = nil, product_version : String? = nil, platform : String? = nil, platform_version : String? = nil do
+    property product, product_version, platform, platform_version
+  end
+
   def initialize(@host = AMQP_HOST, @port = AMQP_PORT, @vhost = AMQP_VHOST, @user = AMQP_USER, @password = AMQP_PASS,
                  tls : TLSContext = AMQP_TLS, @websocket = AMQP_WS, @channel_max = 1024_u16, @frame_max = 131_072_u32, @heartbeat = 0_u16,
                  verify_mode = OpenSSL::SSL::VerifyMode::PEER, @name : String? = File.basename(PROGRAM_NAME),
-                 @tcp = TCPConfig.new, @buffer_size = 16_384, @client_args : String? = nil)
+                 @tcp = TCPConfig.new, @buffer_size = 16_384, @connection_information : ConnectionInformation? = nil)
     if tls.is_a? OpenSSL::SSL::Context::Client
       @tls = tls
     elsif tls == true
@@ -113,17 +117,17 @@ class AMQP::Client
   def connect : Connection
     if @host.starts_with? '/'
       socket = connect_unix
-      Connection.start(socket, @user, @password, @vhost, @channel_max, @frame_max, @heartbeat, @client_args, @name)
+      Connection.start(socket, @user, @password, @vhost, @channel_max, @frame_max, @heartbeat, @connection_information, @name)
     elsif @websocket
       websocket = ::HTTP::WebSocket.new(@host, path: "", port: @port, tls: @tls)
       io = WebSocketIO.new(websocket)
-      Connection.start(io, @user, @password, @vhost, @channel_max, @frame_max, @heartbeat, @client_args, @name)
+      Connection.start(io, @user, @password, @vhost, @channel_max, @frame_max, @heartbeat, @connection_information, @name)
     elsif ctx = @tls.as? OpenSSL::SSL::Context::Client
       socket = connect_tls(connect_tcp, ctx)
-      Connection.start(socket, @user, @password, @vhost, @channel_max, @frame_max, @heartbeat, @client_args, @name)
+      Connection.start(socket, @user, @password, @vhost, @channel_max, @frame_max, @heartbeat, @connection_information, @name)
     else
       socket = connect_tcp
-      Connection.start(socket, @user, @password, @vhost, @channel_max, @frame_max, @heartbeat, @client_args, @name)
+      Connection.start(socket, @user, @password, @vhost, @channel_max, @frame_max, @heartbeat, @connection_information, @name)
     end
   rescue ex
     case ex

--- a/src/amqp-client/connection.cr
+++ b/src/amqp-client/connection.cr
@@ -230,15 +230,12 @@ class AMQP::Client
       io.write AMQ::Protocol::PROTOCOL_START_0_9_1.to_slice
       io.flush
       Frame.from_io(io) { |f| f.as?(Frame::Connection::Start) || raise Error::UnexpectedFrame.new(f) }
-      product_version = connection_information.try(&.product) ? (connection_information.try(&.product_version) || nil) : AMQP::Client::VERSION
-      platform_version = connection_information.try(&.platform) ? (connection_information.try(&.platform_version) || nil) : Crystal::VERSION
-
       props = Arguments.new({
         connection_name:  name,
-        product:          connection_information.try(&.product) || "amqp-client.cr",
-        platform:         connection_information.try(&.platform) || "Crystal",
-        product_version:  product_version,
-        platform_version: platform_version,
+        product:          connection_information.product,
+        platform:         connection_information.platform,
+        product_version:  connection_information.product_version,
+        platform_version: connection_information.platform_version,
         capabilities:     Arguments.new({
           "publisher_confirms":           true,
           "exchange_exchange_bindings":   true,

--- a/src/amqp-client/connection.cr
+++ b/src/amqp-client/connection.cr
@@ -234,12 +234,12 @@ class AMQP::Client
       platform_version = connection_information.try(&.platform) ? (connection_information.try(&.platform_version) || nil) : Crystal::VERSION
 
       props = Arguments.new({
-        connection_name: name,
-        product:         connection_information.try(&.product) || "amqp-client.cr",
-        platform:        connection_information.try(&.platform) || "Crystal",
-        product_version:         product_version,
-        platform_version:        platform_version,
-        capabilities:    Arguments.new({
+        connection_name:  name,
+        product:          connection_information.try(&.product) || "amqp-client.cr",
+        platform:         connection_information.try(&.platform) || "Crystal",
+        product_version:  product_version,
+        platform_version: platform_version,
+        capabilities:     Arguments.new({
           "publisher_confirms":           true,
           "exchange_exchange_bindings":   true,
           "basic.nack":                   true,

--- a/src/amqp-client/connection.cr
+++ b/src/amqp-client/connection.cr
@@ -208,7 +208,7 @@ class AMQP::Client
                    user, password, vhost, channel_max, frame_max, heartbeat, connection_information,
                    name = File.basename(PROGRAM_NAME))
       io.read_timeout = 60
-      start(io, user, password, name, connection_information)
+      start(io, user, password, connection_information, name)
       channel_max, frame_max, heartbeat = tune(io, channel_max, frame_max, heartbeat)
       open(io, vhost)
       Connection.new(io, channel_max, frame_max, heartbeat)
@@ -226,7 +226,7 @@ class AMQP::Client
       io.read_timeout = nil
     end
 
-    private def self.start(io, user, password, name, connection_information)
+    private def self.start(io, user, password, connection_information, name)
       io.write AMQ::Protocol::PROTOCOL_START_0_9_1.to_slice
       io.flush
       Frame.from_io(io) { |f| f.as?(Frame::Connection::Start) || raise Error::UnexpectedFrame.new(f) }

--- a/src/amqp-client/connection.cr
+++ b/src/amqp-client/connection.cr
@@ -231,7 +231,7 @@ class AMQP::Client
       io.flush
       Frame.from_io(io) { |f| f.as?(Frame::Connection::Start) || raise Error::UnexpectedFrame.new(f) }
       props = Arguments.new({
-        connection_name:  name,
+        connection_name:  name || connection_information.name,
         product:          connection_information.product,
         platform:         connection_information.platform,
         product_version:  connection_information.product_version,

--- a/src/amqp-client/connection.cr
+++ b/src/amqp-client/connection.cr
@@ -230,12 +230,15 @@ class AMQP::Client
       io.write AMQ::Protocol::PROTOCOL_START_0_9_1.to_slice
       io.flush
       Frame.from_io(io) { |f| f.as?(Frame::Connection::Start) || raise Error::UnexpectedFrame.new(f) }
+      product_version = connection_information.try(&.product) ? (connection_information.try(&.product_version) || nil) : AMQP::Client::VERSION
+      platform_version = connection_information.try(&.platform) ? (connection_information.try(&.platform_version) || nil) : Crystal::VERSION
+
       props = Arguments.new({
         connection_name: name,
         product:         connection_information.try(&.product) || "amqp-client.cr",
         platform:        connection_information.try(&.platform) || "Crystal",
-        product_version:         connection_information.try(&.product_version) || AMQP::Client::VERSION,
-        platform_version:        connection_information.try(&.platform_version) || Crystal::VERSION,
+        product_version:         product_version,
+        platform_version:        platform_version,
         capabilities:    Arguments.new({
           "publisher_confirms":           true,
           "exchange_exchange_bindings":   true,


### PR DESCRIPTION
This PR lets amqp-client be able to take in external client arguments so it can present more accurate client information for connections. 

In the image below we see it states amqp-client instead of LavinMQ. 
If it was RabbitMQ, it would state RabbitMQ so assuming that is the standard
![image](https://github.com/cloudamqp/amqp-client.cr/assets/85930202/e3f22dd0-2c03-40ed-b7ba-5482f1c71b6e)
