### PR TITLE
Make channel raise `Connection::ClosedException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Specify cacert/cafile/keyfile via URI parameters
 
+### Fixed
+
+- `Channel` methods didn't raise `Connection::ClosedException` if connection had been closed by server.
+
 ## [1.2.5] - 2024-06-17
 
 ### Fixed

--- a/spec/amqp-client_spec.cr
+++ b/spec/amqp-client_spec.cr
@@ -419,9 +419,7 @@ describe AMQP::Client do
         q.publish "foobar"
         expect_raises(AMQP::Client::Connection::ClosedException) do
           ch.basic_consume q.name, block: true do
-            with_http_api do |api|
-              api.close_connections(1)
-            end
+            with_http_api &.close_connections(1)
           end
         end
       end
@@ -429,9 +427,7 @@ describe AMQP::Client do
 
     it "#basic_publish" do
       with_channel do |ch|
-        with_http_api do |api|
-          api.close_connections(1)
-        end
+        with_http_api &.close_connections(1)
         sleep 1 # Wait for connection to be closed
         expect_raises(AMQP::Client::Connection::ClosedException) do
           ch.basic_publish "", "", "foobar"
@@ -441,9 +437,7 @@ describe AMQP::Client do
 
     it "#basic_publish_confirm" do
       with_channel do |ch|
-        with_http_api do |api|
-          api.close_connections(1)
-        end
+        with_http_api &.close_connections(1)
         sleep 1 # Wait for connection to be closed
         expect_raises(AMQP::Client::Connection::ClosedException) do
           ch.basic_publish_confirm "", "", "foobar"

--- a/spec/amqp-client_spec.cr
+++ b/spec/amqp-client_spec.cr
@@ -432,6 +432,7 @@ describe AMQP::Client do
         with_http_api do |api|
           api.close_connections(1)
         end
+        sleep 1 # Wait for connection to be closed
         expect_raises(AMQP::Client::Connection::ClosedException) do
           ch.basic_publish "", "", "foobar"
         end
@@ -443,6 +444,7 @@ describe AMQP::Client do
         with_http_api do |api|
           api.close_connections(1)
         end
+        sleep 1 # Wait for connection to be closed
         expect_raises(AMQP::Client::Connection::ClosedException) do
           ch.basic_publish_confirm "", "", "foobar"
         end

--- a/spec/amqp-client_spec.cr
+++ b/spec/amqp-client_spec.cr
@@ -412,4 +412,42 @@ describe AMQP::Client do
       c.update_secret("foobar", "no reason")
     end
   end
+
+  describe "Channel" do
+    it "#basic_consume block=true will raise Connection::ClosedException if broker closed connection" do
+      with_channel do |ch|
+        ch.queue_declare("foobar")
+        ch.basic_publish "", "", "foobar"
+        expect_raises(AMQP::Client::Connection::ClosedException) do
+          ch.basic_consume "foobar", block: true do
+            with_http_api do |api|
+              api.close_all_connections
+            end
+          end
+        end
+      end
+    end
+
+    it "#basic_publish will raise Connection::ClosedException if broker closed connection" do
+      with_channel do |ch|
+        with_http_api do |api|
+          api.close_all_connections
+        end
+        expect_raises(AMQP::Client::Connection::ClosedException) do
+          ch.basic_publish "", "", "foobar"
+        end
+      end
+    end
+
+    it "#basic_publish_confirm will raise Connection::ClosedException if broker closed connection" do
+      with_channel do |ch|
+        with_http_api do |api|
+          api.close_all_connections
+        end
+        expect_raises(AMQP::Client::Connection::ClosedException) do
+          ch.basic_publish "", "", "foobar"
+        end
+      end
+    end
+  end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -34,6 +34,32 @@ module TestHelpers
       yield c.channel
     end
   end
+
+  struct ManagementApi
+    def initialize(host, port)
+      @http = HTTP::Client.new("localhost", 15672)
+      @http.basic_auth "guest", "guest"
+    end
+
+    def connections
+      get("/api/connections") do |resp|
+        JSON.parse(resp.body_io).as_a
+      end
+    end
+
+    def close_all_connections
+      connections.each do |conn|
+        name = conn["name"].as_s
+        delete("/api/connections/#{URI.encode_path_segment name}")
+      end
+    end
+
+    forward_missing_to @http
+  end
+
+  def with_http_api(&)
+    yield ManagementApi.new("localhost", 15671)
+  end
 end
 
 extend TestHelpers

--- a/src/amqp-client/errors.cr
+++ b/src/amqp-client/errors.cr
@@ -17,8 +17,8 @@ class AMQP::Client
         super(message, cause)
       end
 
-      def initialize(frame : Frame::Connection::Close)
-        super("#{frame.reply_text} (#{frame.reply_code})")
+      def initialize(frame : Frame::Connection::Close, cause : Exception? = nil)
+        super("#{frame.reply_text} (#{frame.reply_code})", cause)
       end
 
       def initialize(message, host, user, vhost)


### PR DESCRIPTION
A `Channel#basic_consume` with `block = true` didn't raise any exception if the connection was closed by the broker, the method just returned. This because we only checked if the channel had been closed, not the connection.

This will add check that the connection hasn't been closed in every place where we checked if the channel has been closed, and if the connection has been closed a `Connection::ClosedException` will be raised.

I've added a few specs, but not all cases are covered.