### PR TITLE
Allow subclassing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,14 @@ jobs:
     continue-on-error: true
     container: 84codes/crystal:latest-ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-      - name: Checkout ameba
-        uses: actions/checkout@v3
-        with:
-          repository: crystal-ameba/ameba
-          path: ameba
-      - name: Build ameba
-        run: make -C ameba
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Shards install
+        run: shards install
+
       - name: Run ameba
-        run: ameba/bin/ameba src spec
+        run: bin/ameba src spec
 
   spec:
     name: Spec
@@ -29,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Shards install
         run: shards install
@@ -45,7 +43,7 @@ jobs:
     container: 84codes/crystal:latest-ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Format check
         run: crystal tool format --check

--- a/examples/PublishSubscribe_consumer.cr
+++ b/examples/PublishSubscribe_consumer.cr
@@ -8,7 +8,7 @@ AMQP::Client.start("amqps://user:password@hostname/vhost") do |c|
     q.subscribe(no_ack: false, block: true) do |msg|
       puts "Received: #{msg.body_io}"
       msg.ack
-      sleep msg.body_io.to_s.count('.')
+      sleep msg.body_io.to_s.count('.').seconds
       puts "Done"
     end
   end

--- a/examples/WorkQueues_consumer.cr
+++ b/examples/WorkQueues_consumer.cr
@@ -8,7 +8,7 @@ AMQP::Client.start("amqps://user:password@hostname/vhost") do |c|
     q.subscribe(no_ack: false, block: true) do |msg|
       puts "Received: #{msg.body_io}"
       msg.ack
-      sleep msg.body_io.to_s.count('.')
+      sleep msg.body_io.to_s.count('.').seconds
       puts "Done"
     end
   end

--- a/spec/amqp-client_spec.cr
+++ b/spec/amqp-client_spec.cr
@@ -220,7 +220,7 @@ describe AMQP::Client do
   it "raises exception on write when the server has closed the connection" do
     with_channel do |ch|
       ch.exchange_declare("foo", "bar", no_wait: true)
-      sleep 0.1
+      sleep 0.1.seconds
       # by now we should've gotten the connection closed by the server
       expect_raises(AMQP::Client::Channel::ClosedException | AMQP::Client::Connection::ClosedException) do
         ch.queue
@@ -285,7 +285,7 @@ describe AMQP::Client do
         5.times do
           names = api.connections.map &.dig("client_properties", "connection_name")
           break if names.includes? "My name"
-          sleep 1
+          sleep 1.seconds
         end
       end
       names.should contain "My Name"
@@ -308,7 +308,7 @@ describe AMQP::Client do
         messages_handled += 1
         ch.basic_cancel(tag)
       end
-      sleep 0.5
+      sleep 0.5.seconds
       (q.message_count + messages_handled).should eq 5
     end
   end
@@ -338,7 +338,7 @@ describe AMQP::Client do
       q.subscribe(no_ack: false, block: false, work_pool: 2) do |_msg|
         raise "myerror"
       end
-      sleep 0.1
+      sleep 0.1.seconds
       ch.closed?.should be_true
       with_channel do |ch2|
         q = ch2.queue_delete("unexpected")
@@ -428,7 +428,7 @@ describe AMQP::Client do
     it "#basic_publish" do
       with_channel do |ch|
         with_http_api &.close_connections(1)
-        sleep 1 # Wait for connection to be closed
+        sleep 1.seconds # Wait for connection to be closed
         expect_raises(AMQP::Client::Connection::ClosedException) do
           ch.basic_publish "", "", "foobar"
         end
@@ -438,7 +438,7 @@ describe AMQP::Client do
     it "#basic_publish_confirm" do
       with_channel do |ch|
         with_http_api &.close_connections(1)
-        sleep 1 # Wait for connection to be closed
+        sleep 1.seconds # Wait for connection to be closed
         expect_raises(AMQP::Client::Connection::ClosedException) do
           ch.basic_publish_confirm "", "", "foobar"
         end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -58,7 +58,7 @@ module TestHelpers
           amount -= 1
         end
         break if amount <= 0
-        sleep 1
+        sleep 1.seconds
       end
     end
 

--- a/spec/websocket_spec.cr
+++ b/spec/websocket_spec.cr
@@ -170,7 +170,7 @@ describe "Websocket client" do
   it "raises exception on write when the server has closed the connection" do
     with_ws_channel do |ch|
       ch.exchange_declare("foo", "bar", no_wait: true)
-      sleep 0.1
+      sleep 0.1.seconds
       # by now we should've gotten the connection closed by the server
       expect_raises(AMQP::Client::Channel::ClosedException) do
         ch.queue
@@ -237,7 +237,7 @@ describe "Websocket client" do
           names = conns.as_a.map &.dig("client_properties", "connection_name")
           break if names.includes? "My name"
         end
-        sleep 1
+        sleep 1.seconds
       end
       names.should contain "My Name"
     end
@@ -259,7 +259,7 @@ describe "Websocket client" do
         messages_handled += 1
         ch.basic_cancel(tag) if ch.has_subscriber?(tag)
       end
-      sleep 0.5
+      sleep 0.5.seconds
       (q.message_count + messages_handled).should eq 5
       q.delete
     end

--- a/src/amqp-client/connection.cr
+++ b/src/amqp-client/connection.cr
@@ -242,7 +242,7 @@ class AMQP::Client
       start(io, user, password, connection_information)
       channel_max, frame_max, heartbeat = tune(io, channel_max, frame_max, heartbeat)
       open(io, vhost)
-      Connection.new(io, channel_max, frame_max, heartbeat)
+      self.new(io, channel_max, frame_max, heartbeat)
     rescue ex
       case ex
       when IO::EOFError


### PR DESCRIPTION
When writing specs for another project I want to allow the client to behave badly. [This](https://github.com/cloudamqp/amqp-client.cr/pull/49/files#diff-67a2b8d13363d24fd4500fb37374db022bd61b7083b798f5e66c1e247acb1177R245) small change allow me to subclass `Connection` to make that possible.

Fixed some deprecation warnings and CI issues while I was at it.