### PR TITLE
Support execution context

### DIFF
--- a/src/amqp-client/connection.cr
+++ b/src/amqp-client/connection.cr
@@ -17,7 +17,11 @@ class AMQP::Client
 
     protected def initialize(@io : UNIXSocket | TCPSocket | OpenSSL::SSL::Socket::Client | WebSocketIO,
                              @channel_max : UInt16, @frame_max : UInt32, @heartbeat : UInt16)
-      spawn read_loop, name: "AMQP::Client#read_loop", same_thread: true
+      {% if flag?(:execution_context) %}
+        spawn read_loop, name: "AMQP::Client#read_loop"
+      {% else %}
+        spawn read_loop, name: "AMQP::Client#read_loop", same_thread: true
+      {% end %}
     end
 
     @channels = Hash(UInt16, Channel).new


### PR DESCRIPTION
In crystal 1.16 execution contexts will be available behind the `execution_context` flag. With execution contexts the `same_thread` argument to `spawn` is deprecated and results in a runtime warning.

This change will check for the `execution_context` flag and call `spawn` without `same_thread` if the flag is set.