### PR TITLE
Fix spec that verifies `channel_max=0` means unlimited 

### DIFF
--- a/spec/amqp-client_spec.cr
+++ b/spec/amqp-client_spec.cr
@@ -279,10 +279,10 @@ describe AMQP::Client do
   end
 
   it "should treat channel_max 0 as unlimited" do
-    # well, at least not zero :)
-    with_connection(channel_max: 0_u16) do |c|
-      ch = c.channel
-      ch.id.should eq 1_u16
+    # LavinMQ defaults to 2048, so "unlimited" should result in error
+    expect_raises(AMQP::Client::Connection::ClosedException, "negotiated channel_max = 0 is higher than the maximum allowed value") do
+      with_connection(channel_max: 0_u16) do |_c|
+      end
     end
   end
 


### PR DESCRIPTION
Since LavinMQ 2.2.0 channel_max=0 is treated as unlimited instead of zero. This broke the `channel_max=0` spec.

The spec will now expect a NOT_ALLOWED error since LavinMQ will default channel_max to 2048.