### PR TITLE
Drop spawn same_thread because it's deprecated with ExecutionContext

### DIFF
--- a/src/amqp-client/channel.cr
+++ b/src/amqp-client/channel.cr
@@ -412,7 +412,6 @@ class AMQP::Client
       @consumers[ok.consumer_tag] = deliveries
       work_pool.times do |i|
         spawn consume(ok.consumer_tag, deliveries, done, i, !block, blk),
-          same_thread: i.zero?, # only force put the first fiber on same thread
           name: "AMQPconsumer##{ok.consumer_tag} ##{i}"
       end
       if block

--- a/src/amqp-client/connection.cr
+++ b/src/amqp-client/connection.cr
@@ -17,7 +17,7 @@ class AMQP::Client
 
     protected def initialize(@io : UNIXSocket | TCPSocket | OpenSSL::SSL::Socket::Client | WebSocketIO,
                              @channel_max : UInt16, @frame_max : UInt32, @heartbeat : UInt16)
-      spawn read_loop, name: "AMQP::Client#read_loop", same_thread: true
+      spawn read_loop, name: "AMQP::Client#read_loop"
     end
 
     @channels = Hash(UInt16, Channel).new


### PR DESCRIPTION
Performance seems satisfactory also without it. We added same_thread because it was a huge performace drain if the read_loop and the message_loop where on different threads and memory had to copied between cores.