### PR TITLE
Fix channel_max negotiation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fixed bug in Channel#exchange_bind [#58](https://github.com/cloudamqp/amqp-client.cr/issues/58) where arguments where swapped
+- Fixed channel_max negotiation logic where client would use unlimited even if the server restricted it
 
 ## [1.3.1] - 2025-04-18
 

--- a/spec/amqp-client_spec.cr
+++ b/spec/amqp-client_spec.cr
@@ -278,14 +278,6 @@ describe AMQP::Client do
     end
   end
 
-  it "should treat channel_max 0 as unlimited" do
-    # LavinMQ defaults to 2048, so "unlimited" should result in error
-    expect_raises(AMQP::Client::Connection::ClosedException, "negotiated channel_max = 0 is higher than the maximum allowed value") do
-      with_connection(channel_max: 0_u16) do |_c|
-      end
-    end
-  end
-
   it "should set connection name", tags: "slow" do
     AMQP::Client.start(name: "My Name") do |_|
       names = Array(String).new

--- a/spec/channel_limit_spec.cr
+++ b/spec/channel_limit_spec.cr
@@ -1,0 +1,38 @@
+require "./spec_helper"
+
+describe "channel_max" do
+  it "should not open more channels than channel_max" do
+    with_connection(channel_max: 10_u16) do |c|
+      c.channel_max.should eq 10_u16
+      channels = [] of AMQP::Client::Channel
+      10.times do
+        channels << c.channel
+      end
+      expect_raises(Exception, "channel_max reached") do
+        c.channel
+      end
+      channels.each &.close
+    end
+  end
+
+  it "should use client's channel_max when it's lower than server's" do
+    # LavinMQ defaults to channel_max=2048
+    with_connection(channel_max: 10_u16) do |c|
+      c.channel_max.should eq 10_u16
+    end
+  end
+
+  it "should use server's channel_max when it's lower than client's" do
+    # LavinMQ defaults to channel_max=2048
+    with_connection(channel_max: 4096_u16) do |c|
+      c.channel_max.should eq 2048_u16
+    end
+  end
+
+  it "should use server's channel_max when client's is 0 (unlimited)" do
+    # LavinMQ defaults to channel_max=2048
+    with_connection(channel_max: 0_u16) do |c|
+      c.channel_max.should eq 2048_u16
+    end
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -11,8 +11,8 @@ Log.setup_from_env
 {% end %}
 
 module TestHelpers
-  def with_connection(**args, &)
-    AMQP::Client.start(**args) do |c|
+  def with_connection(channel_max = 1024_u16, **args, &)
+    AMQP::Client.start(**args, channel_max: channel_max) do |c|
       yield c
     end
   end


### PR DESCRIPTION
Running specs against RabbitMQ exposed an issues with channel_max negotiation

- Add validation to prevent negotiated channel_max = 0 when server has limits
- This prevents the client from claiming unlimited channels when server restricts them
- Ensures proper AMQP connection negotiation compliance
- Rename local variable to negotiated_channel_max for clarity

