### PR TITLE
Add on_disconnect callback for network-level disconnect handling

### DIFF
--- a/spec/connection_spec.cr
+++ b/spec/connection_spec.cr
@@ -74,7 +74,7 @@ describe AMQP::Client::Connection do
       end
     end
 
-    it "logs at debug (not warn) when no on_disconnect callback is registered" do
+    it "logs at error when no on_disconnect callback is registered" do
       done = ::Channel(Nil).new
       port = fake_amqp_server_that_closes(done)
 
@@ -90,10 +90,9 @@ describe AMQP::Client::Connection do
       end
       conn.closed?.should be_true
 
-      backend.entries.any?(&.severity.>=(::Log::Severity::Warn)).should be_false
-      entry = backend.entries.find(&.message.includes?("closed by peer"))
+      entry = backend.entries.find(&.message.includes?("connection closed unexpectedly"))
       entry.should_not be_nil
-      entry.try(&.severity).should eq ::Log::Severity::Debug
+      entry.try(&.severity).should eq ::Log::Severity::Error
     end
   end
 end

--- a/spec/connection_spec.cr
+++ b/spec/connection_spec.cr
@@ -1,0 +1,99 @@
+require "./spec_helper"
+
+private def fake_amqp_server_that_closes(done : ::Channel(Nil)) : Int32
+  server = TCPServer.new("127.0.0.1", 0)
+  port = server.local_address.port
+  format = IO::ByteFormat::NetworkEndian
+
+  spawn(name: "fake-amqp-server") do
+    sock = server.accept
+    sock.read_fully(Bytes.new(8))
+    sock.write_bytes(AMQ::Protocol::Frame::Connection::Start.new, format)
+    sock.flush
+    AMQ::Protocol::Stream.new(sock).next_frame { |_f| } # StartOk
+    sock.write_bytes(AMQ::Protocol::Frame::Connection::Tune.new, format)
+    sock.flush
+    AMQ::Protocol::Stream.new(sock).next_frame { |_f| } # TuneOk
+    AMQ::Protocol::Stream.new(sock).next_frame { |_f| } # Open
+    sock.write_bytes(AMQ::Protocol::Frame::Connection::OpenOk.new, format)
+    sock.flush
+    sock.close
+  ensure
+    server.close
+    done.send nil
+  end
+
+  port
+end
+
+describe AMQP::Client::Connection do
+  describe "network-level disconnect" do
+    it "invokes on_disconnect with the exception when read_loop sees IO::Error" do
+      done = ::Channel(Nil).new
+      port = fake_amqp_server_that_closes(done)
+
+      callback_received = ::Channel(Exception).new(1)
+      conn = AMQP::Client.new(host: "127.0.0.1", port: port).connect
+      conn.on_disconnect do |ex|
+        callback_received.send(ex)
+      end
+      done.receive
+
+      select
+      when ex = callback_received.receive
+        ex.should be_a(IO::Error)
+      when timeout(2.seconds)
+        fail "on_disconnect was not invoked within 2s of peer disconnect"
+      end
+
+      conn.closed?.should be_true
+    end
+
+    it "does not invoke on_close on a network-level disconnect" do
+      done = ::Channel(Nil).new
+      port = fake_amqp_server_that_closes(done)
+
+      on_close_received = ::Channel({UInt16, String}).new(1)
+      conn = AMQP::Client.new(host: "127.0.0.1", port: port).connect
+      conn.on_close do |code, text|
+        on_close_received.send({code, text})
+      end
+      done.receive
+
+      30.times do
+        break if conn.closed?
+        sleep 50.milliseconds
+      end
+      conn.closed?.should be_true
+
+      select
+      when on_close_received.receive
+        fail "on_close should not fire on network-level disconnect"
+      when timeout(200.milliseconds)
+        # expected
+      end
+    end
+
+    it "logs at debug (not warn) when no on_disconnect callback is registered" do
+      done = ::Channel(Nil).new
+      port = fake_amqp_server_that_closes(done)
+
+      backend = ::Log::MemoryBackend.new
+      Log.builder.bind "amqp.client.connection", :debug, backend
+
+      conn = AMQP::Client.new(host: "127.0.0.1", port: port).connect
+      done.receive
+
+      30.times do
+        break if conn.closed?
+        sleep 50.milliseconds
+      end
+      conn.closed?.should be_true
+
+      backend.entries.any?(&.severity.>=(::Log::Severity::Warn)).should be_false
+      entry = backend.entries.find(&.message.includes?("closed by peer"))
+      entry.should_not be_nil
+      entry.try(&.severity).should eq ::Log::Severity::Debug
+    end
+  end
+end

--- a/src/amqp-client/connection.cr
+++ b/src/amqp-client/connection.cr
@@ -67,9 +67,19 @@ class AMQP::Client
 
     @on_close : Proc(UInt16, String, Nil)?
 
-    # Callback that's called if the `Connection` is closed by the server
+    # Callback called when the server closes the `Connection`
+    # gracefully via an AMQP `Connection.Close` method frame.
     def on_close(&blk : UInt16, String ->)
       @on_close = blk
+    end
+
+    @on_disconnect : Proc(Exception, Nil)?
+
+    # Callback called when the `Connection` is lost at the network
+    # layer — i.e. the read loop encountered `IO::Error` or `OpenSSL::Error`
+    # without a preceding AMQP `Connection.Close` frame.
+    def on_disconnect(&blk : Exception ->)
+      @on_disconnect = blk
     end
 
     @on_blocked : Proc(String, Nil)?
@@ -118,7 +128,7 @@ class AMQP::Client
           end
         end
       rescue ex : IO::Error | OpenSSL::Error
-        Log.error(exception: ex) { "connection closed unexpectedly: #{ex.message}" }
+        notify_disconnected(ex)
         break
       rescue ex
         Log.error(exception: ex) { "read_loop exception: #{ex.inspect}" }
@@ -132,6 +142,18 @@ class AMQP::Client
       @channels_lock.synchronize do
         @channels.each_value &.cleanup
         @channels.clear
+      end
+    end
+
+    private def notify_disconnected(ex : Exception)
+      if on_disconnect = @on_disconnect
+        begin
+          on_disconnect.call(ex)
+        rescue e
+          Log.error(exception: e) { "Uncaught exception in on_disconnect block" }
+        end
+      else
+        Log.debug(exception: ex) { "connection closed by peer: #{ex.class}: #{ex.message}" }
       end
     end
 

--- a/src/amqp-client/connection.cr
+++ b/src/amqp-client/connection.cr
@@ -153,7 +153,7 @@ class AMQP::Client
           Log.error(exception: e) { "Uncaught exception in on_disconnect block" }
         end
       else
-        Log.debug(exception: ex) { "connection closed by peer: #{ex.class}: #{ex.message}" }
+        Log.error(exception: ex) { "connection closed unexpectedly: #{ex.message}" }
       end
     end
 


### PR DESCRIPTION
Adds `Connection#on_disconnect(Exception ->)` callback that fires when the read loop encounters `IO::Error` or `OpenSSL::Error` without a preceding AMQP `Connection.Close` frame. Typical triggers: broker restart, TCP reset, NAT timeout dropping an idle connection.

`on_close` semantics are unchanged — it still only fires on graceful AMQP-level closes initiated by the server. The two callbacks are now disjoint.

**Logging behavior:**
- No callback registered → existing `Log.error("connection closed unexpectedly: ...")` is preserved, so downstream log → Sentry pipelines that rely on this signal keep working.
- `on_disconnect` registered → the library suppresses its own log and hands the exception to the callback; the caller decides what (if anything) to log.

The intent is to remove the fallback `Log.error` in a future release, once users have had time to migrate to the callback. 