### PR TITLE
Parse `verify` URI param with `OpenSSL::SSL::VerifyMode.parse?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Any valid verify mode can now be set via the `verify` URI parameter, not just `verify=none`. [#72](https://github.com/cloudamqp/amqp-client.cr/pull/72)
+
 ## [1.3.3] - 2026-05-27
 
 ### Added
+
 - Set Sec-WebSocket-Protocol header to 'amqp' for WebSocket connections [#68](https://github.com/cloudamqp/amqp-client.cr/pull/68)
 - Allow passing NamedTuple where `Arguments` was required before [#56](https://github.com/cloudamqp/amqp-client.cr/pull/56)
 
 ### Changed
+
 - No version restriction of amq-protocol.cr, so that users of the library can override amq-protocol with for example a branch version
 - Wrap network exceptions in AMQP::Error::NetworkError [#64](https://github.com/cloudamqp/amqp-client.cr/pull/64)
 

--- a/spec/amqp-client_spec.cr
+++ b/spec/amqp-client_spec.cr
@@ -381,6 +381,33 @@ describe AMQP::Client do
     conn2.@io.class.should eq OpenSSL::SSL::Socket::Client
   end
 
+  describe "verify URI parameter" do
+    it "sets verify_mode to NONE for verify=none" do
+      client = AMQP::Client.new("amqps://localhost?verify=none")
+      client.tls.try(&.verify_mode).should eq OpenSSL::SSL::VerifyMode::NONE
+    end
+
+    it "parses the value case-insensitively" do
+      client = AMQP::Client.new("amqps://localhost?verify=None")
+      client.tls.try(&.verify_mode).should eq OpenSSL::SSL::VerifyMode::NONE
+    end
+
+    it "supports other verify modes, e.g. peer" do
+      client = AMQP::Client.new("amqps://localhost?verify=peer")
+      client.tls.try(&.verify_mode).should eq OpenSSL::SSL::VerifyMode::PEER
+    end
+
+    it "ignores an unrecognised value and keeps the PEER default" do
+      client = AMQP::Client.new("amqps://localhost?verify=garbage")
+      client.tls.try(&.verify_mode).should eq OpenSSL::SSL::VerifyMode::PEER
+    end
+
+    it "defaults to PEER when no verify param is given" do
+      client = AMQP::Client.new("amqps://localhost")
+      client.tls.try(&.verify_mode).should eq OpenSSL::SSL::VerifyMode::PEER
+    end
+  end
+
   it "version matches shard version" do
     AMQP::Client::VERSION == {{ `shards version`.stringify }}
   end

--- a/src/amqp-client.cr
+++ b/src/amqp-client.cr
@@ -86,7 +86,7 @@ class AMQP::Client
       when "tcp_keepalive"
         ka = value.split(':', 3).map &.to_i
         tcp.keepalive_idle, tcp.keepalive_interval, tcp.keepalive_count = ka
-      when "verify"     then tls_ctx.try &.verify_mode = OpenSSL::SSL::VerifyMode::NONE if value =~ /^none$/i
+      when "verify"     then OpenSSL::SSL::VerifyMode.parse?(value).try { |mode| tls_ctx.try &.verify_mode = mode }
       when "cacertfile" then tls_ctx.try &.ca_certificates_path = value
       when "certfile"   then tls_ctx.try &.certificate_chain = value
       when "keyfile"    then tls_ctx.try &.private_key = value


### PR DESCRIPTION
Replaces the `/^none$/i` regex check with `VerifyMode.parse?`, so any valid verify mode can be set via the URI (e.g. `verify=peer`), not just `'none'`.

Parsing is case-insensitive and unrecognised values are ignored, keeping the `PEER` default so verification stays enabled on bad input.
