### PR TITLE
Document silent disconnect handling in read_loop (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,44 @@ AMQP::Client.start("amqp://guest:guest@localhost") do |c|
 end
 ```
 
+## Connection close and network failures
+
+`Connection#on_close` is only called when the broker sends an AMQP
+connection close frame. If the TCP/TLS/WebSocket socket read fails without an
+AMQP close frame, the background read loop logs the IO/OpenSSL error, marks the
+connection closed, closes channels and consumers, and exits. It does not call
+`on_close`, and the original transport exception is not delivered to
+application code.
+
+For long-running consumers that wait on an application-owned shutdown channel,
+also watch `Connection#closed?` so a detected disconnect can unblock the
+application:
+
+```crystal
+require "amqp-client"
+
+AMQP::Client.start("amqp://guest:guest@localhost") do |c|
+  shutdown = ::Channel(Nil).new
+  Signal::INT.trap { shutdown.close rescue nil }
+
+  spawn do
+    until c.closed?
+      sleep 1.second
+    end
+    shutdown.close rescue nil
+  end
+
+  ch = c.channel
+  q = ch.queue("events")
+  q.subscribe(no_ack: false) do |msg|
+    puts "Received: #{msg.body_io}"
+    msg.ack
+  end
+
+  shutdown.receive?
+end
+```
+
 You can consume [stream queues](https://www.rabbitmq.com/streams.html) too: 
 
 ```crystal

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,15 @@ dependencies:
 ```
 2. Run `shards install`
 
+## Connection close and network failures
+
+The `on_close` callback is only called for broker-initiated AMQP close frames.
+If the TCP/TLS/WebSocket socket read fails without an AMQP close frame, the
+client read loop logs the error and marks the connection closed, but it does
+not call `on_close` or wake an application-owned shutdown channel. Long-running
+consumers should also watch `Connection#closed?` when deciding when to
+reconnect or exit.
+
 ## “Hello World!”
 
 In this example we will write two small programs in Crystal; a publisher that sends a message, and a consumer that receives messages and prints them out.

--- a/src/amqp-client/connection.cr
+++ b/src/amqp-client/connection.cr
@@ -12,6 +12,9 @@ class AMQP::Client
     @reply_frames = ::Channel(Frame).new
     getter closing_frame : Frame::Connection::Close?
     getter channel_max, frame_max
+    # Returns `true` once the connection is closed, whether closed cleanly, by
+    # the server, or by an unexpected transport failure. Poll this to detect
+    # disconnects that don't trigger `#on_close` (see `#on_close`).
     getter? closed = false
     getter? blocked = false
 
@@ -67,7 +70,14 @@ class AMQP::Client
 
     @on_close : Proc(UInt16, String, Nil)?
 
-    # Callback that's called if the `Connection` is closed by the server
+    # Callback that's called if the `Connection` is closed by the server.
+    #
+    # NOTE: This is only called when the broker sends an AMQP connection close
+    # frame. It is *not* called on unexpected transport failures (TCP/TLS/
+    # WebSocket read errors, timeouts, network partitions). In those cases the
+    # background read loop logs the error, marks the connection closed and exits
+    # without invoking this callback. To detect such disconnects, poll
+    # `#closed?`.
     def on_close(&blk : UInt16, String ->)
       @on_close = blk
     end


### PR DESCRIPTION
Closes #70.

When the TCP/TLS/WebSocket connection drops without an AMQP close frame (timeout, network partition, etc.), `read_loop` rescues `IO::Error | OpenSSL::Error`, logs it, marks the connection closed, and exits — but never invokes `on_close`. That callback only fires for broker-initiated AMQP `Connection::Close` frames. The only way to detect an unexpected disconnect is to poll `Connection#closed?`, and this was undocumented.

This is a **docs-only** change (no behavior change to `read_loop`):

- **README.md** — new "Connection close and network failures" section explaining the limitation, with a worked example that polls `closed?` to unblock an application-owned shutdown channel.
- **examples/README.md** — a shorter version of the same note.
- **src/amqp-client/connection.cr** — doc comments on `on_close` (clarifying it does not fire on transport failures) and `closed?` (documenting it covers unexpected disconnects, with a cross-reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)